### PR TITLE
Introduce linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,42 @@
+run:
+  deadline: 5m
+  allow-parallel-runners: true
+
+linters:
+  enable:
+    - gofmt
+    - staticcheck
+    - gosimple
+    - unused
+    - tparallel
+    - paralleltest
+    - prealloc
+    - unparam # This was added while we used go1.18 which means it's always been disabled. It may eventually be re-enabled and we'll need to fix what it finds
+  presets:
+    - bugs
+    - unused
+  disable:
+    - musttag # Extremely slow, at least on CI machines
+linters-settings:
+  cyclop:
+    max-complexity: 10
+    skip-tests: true
+  exhaustive:
+    default-signifies-exhaustive: true
+  gosimple:
+    # See https://golangci-lint.run/usage/linters#gosimple for a breakdown of what's checked by this linter
+    checks:
+      - "all"
+      - "-S1002" # Comparison to bool explicitly can sometimes add clarity
+      - "-S1016" # Uncommon language feature, encourages coupling when it may not be appropriate
+  govet:
+    shadow: true
+  nolintlint:
+    allow-unused: false
+    require-explanation: true
+    require-specific: true
+  prealloc:
+    simple: false
+    for-loops: true
+  unused:
+    generated-is-used: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,13 +5,13 @@ run:
 linters:
   enable:
     - gofmt
-    - staticcheck
     - gosimple
-    - unused
-    - tparallel
     - paralleltest
     - prealloc
-    - unparam # This was added while we used go1.18 which means it's always been disabled. It may eventually be re-enabled and we'll need to fix what it finds
+    - staticcheck
+    - tparallel
+    - unparam
+    - unused
   presets:
     - bugs
     - unused

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -93,14 +93,14 @@ tasks:
       CONFIG: '{{joinPath .DST_DIR "capz.yaml" | shellQuote}}'
 
   tidy:
-    summary: "Tidy up source"
+    desc: "Tidy up source"
 
   tidy.gofumpt:
-    summary: "Run gofumpt"
+    desc: "Run gofumpt"
     cmds:
       - gofumpt -l -w .
 
   tidy.mod:
-    summary: "Run go mod tidy"
+    desc: "Run go mod tidy"
     cmds:
       - go mod tidy

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,14 +1,13 @@
 # https://taskfile.dev
 
-version: '3'
+version: "3"
 
 vars:
-  SAMPLES_DIR: "{{ list .ROOT_DIR \"samples\" | join \"/\" | osClean }}"
+  SAMPLES_DIR: '{{ list .ROOT_DIR "samples" | join "/" | osClean }}'
 
 run: once
 
 tasks:
-
   default:
     desc: Run all tasks
     deps:
@@ -21,11 +20,22 @@ tasks:
       - go build
 
   test:
+    desc: Run tests and checks
+    deps:
+      - test.unit
+      - test.lint
+
+  test.unit:
     desc: Run unit tests
     deps:
       - build
     cmds:
       - go test ./...
+
+  test.lint:
+    desc: Run golangci-lint to check for linting issues
+    cmds:
+      - golangci-lint run
 
   ci:
     desc: Run continuous integration tasks
@@ -33,7 +43,7 @@ tasks:
       - test
 
   docs:
-    summary: Build documentation 
+    summary: Build documentation
     deps:
       - docs.config
       - docs.aso
@@ -41,7 +51,7 @@ tasks:
 
   docs.config:
     summary: Build documentation of config options
-    deps: 
+    deps:
       - build
     cmds:
       - ./crddoc document-package {{.PACKAGE}} --output {{.OUTPUT}} --config {{.CONFIG}}
@@ -50,12 +60,14 @@ tasks:
       PACKAGE: '{{joinPath .ROOT_DIR "internal" "config" | shellQuote}}'
       OUTPUT: '{{joinPath .DST_DIR "config.md" | shellQuote}}'
       CONFIG: '{{joinPath .DST_DIR "crddoc-config.yaml" | shellQuote}}'
-    
 
   docs.aso:
     summary: Build example showing documentation for Azure Service Operator
-    deps: 
+    deps:
       - build
+    status:
+      # Skip if the package isn't available
+      - test ! -d {{.PACKAGE}}
     cmds:
       - ./crddoc document-package {{.PACKAGE}} --output {{.OUTPUT}} --config {{.CONFIG}}
     vars:
@@ -66,8 +78,11 @@ tasks:
 
   docs.capz:
     summary: Build example showing documentation for Cluster API Provider Azure
-    deps: 
+    deps:
       - build
+    status:
+      # Skip if the package isn't available
+      - test ! -d {{.PACKAGE}}
     cmds:
       - ./crddoc document-package {{.PACKAGE}} --output {{.OUTPUT}} --config {{.CONFIG}}
     vars:
@@ -76,3 +91,16 @@ tasks:
       PACKAGE: '{{joinPath .ROOT_DIR "../cluster-api-provider-azure/api/v1beta1" | shellQuote}}'
       OUTPUT: '{{joinPath .DST_DIR "capz.md" | shellQuote}}'
       CONFIG: '{{joinPath .DST_DIR "capz.yaml" | shellQuote}}'
+
+  tidy:
+    summary: "Tidy up source"
+
+  tidy.gofumpt:
+    summary: "Run gofumpt"
+    cmds:
+      - gofumpt -l -w .
+
+  tidy.mod:
+    summary: "Run go mod tidy"
+    cmds:
+      - go mod tidy

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -22,17 +22,17 @@ tasks:
   test:
     desc: Run tests and checks
     deps:
-      - test.unit
-      - test.lint
+      - unit-test
+      - lint
 
-  test.unit:
+  unit-test:
     desc: Run unit tests
     deps:
       - build
     cmds:
       - go test ./...
 
-  test.lint:
+  lint:
     desc: Run golangci-lint to check for linting issues
     cmds:
       - golangci-lint run

--- a/cmd/document-package.go
+++ b/cmd/document-package.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"bufio"
-	"context"
 	"os"
 
 	"github.com/pkg/errors"
@@ -23,8 +22,7 @@ func newDocumentPackageCommand(log logr.Logger) (*cobra.Command, error) {
 		Short: "Generate documentation for a package",
 		Long:  "Generate documentation for a package.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
-			return documentPackage(ctx, args, options, log)
+			return documentPackage(args, options, log)
 		},
 	}
 
@@ -56,7 +54,6 @@ type documentPackageOptions struct {
 }
 
 func documentPackage(
-	ctx context.Context,
 	args []string,
 	options *documentPackageOptions,
 	log logr.Logger,

--- a/cmd/export-templates.go
+++ b/cmd/export-templates.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"context"
-
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -18,8 +16,7 @@ func newExportTemplatesCommand(
 		Short: "Export standard templates to a folder",
 		Long:  "Export the templates contained within crddoc to a folder for customization.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := cmd.Context()
-			return exportTemplates(ctx, args, options, log)
+			return exportTemplates(args, options, log)
 		},
 	}
 
@@ -37,10 +34,9 @@ type exportTemplateOptions struct {
 }
 
 func exportTemplates(
-	ctx context.Context,
-	args []string,
+	_ []string,
 	options *exportTemplateOptions,
-	log logr.Logger,
+	_ logr.Logger,
 ) error {
 	if err := options.validate(); err != nil {
 		return err

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -50,7 +50,10 @@ func (g *Generator) Generate(pkg *model.Package, writer io.Writer) error {
 	)
 
 	g.fns.SetPackage(pkg)
-	g.fns.SetConfig(g.cfg)
+	if err := g.fns.SetConfig(g.cfg); err != nil {
+		g.log.Error(err, "failed to set function config")
+		return errors.Wrap(err, "failed to set")
+	}
 
 	var raw bytes.Buffer
 	err := g.template.ExecuteTemplate(

--- a/internal/model/comments.go
+++ b/internal/model/comments.go
@@ -1,0 +1,23 @@
+package model
+
+import (
+	"strings"
+
+	"golang.org/x/exp/slices"
+)
+
+func formatComments(
+	comments []string,
+	name string,
+) []string {
+	result := slices.Clone(comments)
+	if len(comments) == 0 {
+		return result
+	}
+
+	if s, ok := strings.CutPrefix(result[0], name+": "); ok {
+		result[0] = strings.TrimLeft(s, " ")
+	}
+
+	return result
+}

--- a/internal/model/object.go
+++ b/internal/model/object.go
@@ -1,8 +1,6 @@
 package model
 
 import (
-	"strings"
-
 	"github.com/dave/dst"
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
@@ -37,14 +35,9 @@ func TryNewObject(spec dst.Spec, comments []string) (*Object, bool) {
 	}
 
 	ref := NewTypeReference(typeSpec.Name)
+	// Clean up the comments
 	description, _ := ParseComments(comments)
-
-	// If the first line of the description starts with "<name>: ", remove that prefix
-	if len(description) > 0 {
-		if s, ok := strings.CutPrefix(description[0], ref.Name()+": "); ok {
-			description[0] = strings.TrimLeft(s, " ")
-		}
-	}
+	description = formatComments(description, ref.Name())
 
 	result := &Object{
 		TypeReference: ref,

--- a/internal/model/package_test.go
+++ b/internal/model/package_test.go
@@ -77,7 +77,10 @@ func TestPackage_Object_ReturnsExpectedObjects(t *testing.T) {
 }
 
 // loadTestData is a helper used to load a testdata source file
-func testdataPath(t *testing.T, filename string) string {
+func testdataPath(
+	t *testing.T,
+	filename string, //nolint:unparam // other file names will be used as testing improves
+) string {
 	t.Helper()
 
 	wd, err := os.Getwd()

--- a/internal/model/parser.go
+++ b/internal/model/parser.go
@@ -4,6 +4,7 @@ import "strings"
 
 // ParseComments iterates over the comments and returns the description and any commands that are
 // not part of the description
+// TODO: Add optional varidic "cleanup" functions to allow for more complex comment parsing and cleanup.
 func ParseComments(comments []string) ([]string, *Markers) {
 	description := make([]string, 0, len(comments))
 	commands := NewMarkers()

--- a/internal/model/property.go
+++ b/internal/model/property.go
@@ -19,13 +19,7 @@ func TryNewProperty(name string, field *dst.Field) (*Property, bool) {
 	// TODO: Parse tags
 
 	description, commands := ParseComments(field.Decs.Start.All())
-
-	// If the first line of the description starts with "<property>: ", remove that prefix
-	if len(description) > 0 {
-		if s, ok := strings.CutPrefix(description[0], name+": "); ok {
-			description[0] = strings.TrimLeft(s, " ")
-		}
-	}
+	description = formatComments(description, name)
 
 	result := &Property{
 		Field:       name,

--- a/internal/packageloader/fileloader_test.go
+++ b/internal/packageloader/fileloader_test.go
@@ -82,7 +82,10 @@ func TestFileLoader_Load_GivenPartyFile_ReturnsExpectedVersion(t *testing.T) {
 }
 
 // loadTestData is a helper used to load a testdata source file
-func testdataPath(t *testing.T, filename string) string {
+func testdataPath(
+	t *testing.T,
+	filename string, // nolint:unparam // other file names will be used as testing improves
+) string {
 	t.Helper()
 
 	wd, err := os.Getwd()

--- a/internal/packageloader/packageloader_test.go
+++ b/internal/packageloader/packageloader_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func Test_TryReadMetadata_WhenModFileMissing_ReturnsFalse(t *testing.T) {
+	t.Parallel()
 	g := NewGomegaWithT(t)
 
 	loader := PackageLoader{}
@@ -16,6 +17,7 @@ func Test_TryReadMetadata_WhenModFileMissing_ReturnsFalse(t *testing.T) {
 }
 
 func Test_TryReadMetadata_WhenModFilePresent_ReturnsExpectedResults(t *testing.T) {
+	t.Parallel()
 	g := NewGomegaWithT(t)
 
 	loader := PackageLoader{}

--- a/templates/templates.go
+++ b/templates/templates.go
@@ -3,5 +3,6 @@ package templates
 import "embed"
 
 // Default CRD template
+//
 //go:embed *.tmpl
 var CRD embed.FS


### PR DESCRIPTION
Set up simple infrastructure for using golangci-lint on a regular basis. 

Initial set of enabled linters is minimal, will expand over time.