### PR TITLE
Enable revive linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,5 +39,14 @@ linters-settings:
   prealloc:
     simple: false
     for-loops: true
+  revive:
+    rules:
+      - name: dot-imports
+        arguments:
+          [
+            "allowedPackages":
+              ["github.com/onsi/ginkgo/v2", "github.com/onsi/gomega"],
+          ]
+
   unused:
     generated-is-used: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,7 @@ linters:
     - gosimple
     - paralleltest
     - prealloc
+    - revive
     - staticcheck
     - tparallel
     - unparam

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,6 +51,8 @@ linters-settings:
         disabled: false
       - name: import-shadowing
         disabled: false
+      - name: indent-error-flow
+        disabled: false
       - name: line-length-limit
         disabled: false
         arguments: [100]

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -47,6 +47,9 @@ linters-settings:
             "allowedPackages":
               ["github.com/onsi/ginkgo/v2", "github.com/onsi/gomega"],
           ]
+      - name: line-length-limit
+        disabled: false
+        arguments: [100]
 
   unused:
     generated-is-used: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -47,6 +47,8 @@ linters-settings:
             "allowedPackages":
               ["github.com/onsi/ginkgo/v2", "github.com/onsi/gomega"],
           ]
+      - name: empty-lines
+        disabled: false
       - name: import-shadowing
         disabled: false
       - name: line-length-limit

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -47,6 +47,8 @@ linters-settings:
             "allowedPackages":
               ["github.com/onsi/ginkgo/v2", "github.com/onsi/gomega"],
           ]
+      - name: import-shadowing
+        disabled: false
       - name: line-length-limit
         disabled: false
         arguments: [100]

--- a/cmd/document-package.go
+++ b/cmd/document-package.go
@@ -21,7 +21,7 @@ func newDocumentPackageCommand(log logr.Logger) (*cobra.Command, error) {
 		Use:   "document-package",
 		Short: "Generate documentation for a package",
 		Long:  "Generate documentation for a package.",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			return documentPackage(args, options, log)
 		},
 	}

--- a/cmd/export-configuration.go
+++ b/cmd/export-configuration.go
@@ -14,20 +14,23 @@ func newExportConfigurationCommand(
 	cmd := &cobra.Command{
 		Use:   "configuration",
 		Short: "Export standard configuration to a file",
-		Long:  "Export the default configuration to a file for customization.",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			return exportConfiguration(args, options)
+		Long:  "Export default configuration to a file for customization.",
+		RunE: func(_ *cobra.Command, args []string) error {
+			return exportConfiguration(args, options, log)
 		},
 	}
 
 	return cmd, nil
 }
 
+// exportConfigurationOptions defines any optional parameters for template export.
+// Currently there are none.
 type exportConfigurationOptions struct{}
 
 func exportConfiguration(
 	args []string,
 	_ *exportConfigurationOptions,
+	log logr.Logger,
 ) error {
 	if len(args) == 0 {
 		return errors.New("no export file supplied")
@@ -41,5 +44,6 @@ func exportConfiguration(
 	cfg := config.Default()
 
 	// Save the configuration to a file as yaml
+	log.Info("Saving default configuration to file", "file", args[0])
 	return cfg.Save(args[0])
 }

--- a/cmd/export-templates.go
+++ b/cmd/export-templates.go
@@ -15,7 +15,7 @@ func newExportTemplatesCommand(
 		Use:   "templates",
 		Short: "Export standard templates to a folder",
 		Long:  "Export the templates contained within crddoc to a folder for customization.",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			return exportTemplates(args, options, log)
 		},
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,7 +50,10 @@ func newRootCommand(log logr.Logger) (*cobra.Command, error) {
 		rootCmd.AddCommand(cmd)
 	}
 
-	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
+	rootCmd.PersistentPreRun = func(
+		_ *cobra.Command,
+		_ []string,
+	) {
 		if verbose {
 			verboseLogging()
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,17 +9,21 @@ import (
 )
 
 type Config struct {
-	// Editors allow you to make precision changes to the documentation output. Editors are applied in the order specified.
+	// Editors allow you to make precision changes to the documentation output.
+	// Editors are applied in the order specified.
 	Editors []Editor `yaml:"editors"`
 
 	// TypeFilters allow you to filter out types from the output.
-	// Filters are applied in the order specified, with earlier filters taking priority over later ones.
+	// Filters are applied in the order specified,
+	// with earlier filters taking priority over later ones.
 	TypeFilters []*Filter `yaml:"typeFilters"`
 
-	// PrettyPrint controls whether the Markdown output is pretty-printed or not. Defaults to true.
+	// PrettyPrint controls whether the Markdown output is pretty-printed or not.
+	// Defaults to true.
 	PrettyPrint bool `yaml:"prettyPrint"`
 
-	// TemplatePath is the path to folder containing templates to use for rendering the documentation.
+	// TemplatePath is the path to a folder containing templates to use for
+	// rendering the documentation.
 	TemplatePath string `yaml:"templatePath"`
 }
 

--- a/internal/config/editor.go
+++ b/internal/config/editor.go
@@ -3,6 +3,8 @@ package config
 import (
 	"fmt"
 	"regexp"
+
+	"github.com/pkg/errors"
 )
 
 // Editor represents a point modification to make to exported documentation
@@ -22,17 +24,17 @@ func (edit *Editor) Validate() error {
 	if edit.Context != "" {
 		_, err := regexp.Compile(edit.Context)
 		if err != nil {
-			return fmt.Errorf("unable to compile 'context': %w", err)
+			return errors.Wrap(err, "compiling editor context expression")
 		}
 	}
 
 	if edit.Search == "" {
-		return fmt.Errorf("editor 'search' may not be empty")
-	} else {
-		_, err := regexp.Compile(edit.Search)
-		if err != nil {
-			return fmt.Errorf("unable to compile 'search': %w", err)
-		}
+		return fmt.Errorf("editor search expression may not be empty")
+	}
+
+	_, err := regexp.Compile(edit.Search)
+	if err != nil {
+		return errors.Wrap(err, "compiling editor search expression")
 	}
 
 	return nil

--- a/internal/config/editor_test.go
+++ b/internal/config/editor_test.go
@@ -22,7 +22,7 @@ func TestEditor_Validate_WhenContextIsInvalidRegex_ReturnsExpectedError(t *testi
 
 	// Assert
 	g.Expect(err).To(gomega.HaveOccurred())
-	g.Expect(err.Error()).To(gomega.ContainSubstring("unable to compile 'context':"))
+	g.Expect(err.Error()).To(gomega.ContainSubstring("compiling editor context expression"))
 }
 
 func TestEditor_WhenSearchIsMissing_ReturnsExpectedError(t *testing.T) {
@@ -38,7 +38,7 @@ func TestEditor_WhenSearchIsMissing_ReturnsExpectedError(t *testing.T) {
 
 	// Assert
 	g.Expect(err).To(gomega.HaveOccurred())
-	g.Expect(err.Error()).To(gomega.ContainSubstring("editor 'search' may not be empty"))
+	g.Expect(err.Error()).To(gomega.ContainSubstring("editor search expression may not be empty"))
 }
 
 func TestEditor_Validate_WhenSearchIsInvalidRegex_ReturnsExpectedError(t *testing.T) {
@@ -56,5 +56,5 @@ func TestEditor_Validate_WhenSearchIsInvalidRegex_ReturnsExpectedError(t *testin
 
 	// Assert
 	g.Expect(err).To(gomega.HaveOccurred())
-	g.Expect(err.Error()).To(gomega.ContainSubstring("unable to compile 'search':"))
+	g.Expect(err.Error()).To(gomega.ContainSubstring("compiling editor search expression"))
 }

--- a/internal/functions/inline_links_test.go
+++ b/internal/functions/inline_links_test.go
@@ -20,10 +20,12 @@ func TestInlineLinks_GivenLines_ReturnsExpectedLines(t *testing.T) {
 				"KubeletConfig defines the supported subset of kubelet configurations",
 				"for nodes in pools. See also [AKS doc], [K8s doc].",
 				"[AKS doc]: https://learn.microsoft.com/azure/aks/custom-node-configuration",
+				//nolint:revive // disable long-line-length because test cases are long
 				"[K8s doc]: https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/",
 			},
 			expected: []string{
 				"KubeletConfig defines the supported subset of kubelet configurations",
+				//nolint:revive // disable long-line-length because test cases are long
 				"for nodes in pools. See also [AKS doc](https://learn.microsoft.com/azure/aks/custom-node-configuration), [K8s doc](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/).",
 			},
 		},

--- a/internal/model/enum.go
+++ b/internal/model/enum.go
@@ -17,7 +17,7 @@ func TryNewEnum(spec dst.Spec, comments []string) (*Enum, bool) {
 		return nil, false
 	}
 
-	// TEmp - skip structs
+	// ... (skipping structs) ...
 	if _, ok := typeSpec.Type.(*dst.StructType); ok {
 		return nil, false
 	}
@@ -31,6 +31,7 @@ func TryNewEnum(spec dst.Spec, comments []string) (*Enum, bool) {
 	result := &Enum{
 		TypeReference: NewTypeReference(typeSpec.Name),
 		base:          NewTypeReference(ident),
+		description:   comments,
 	}
 
 	return result, true

--- a/internal/model/package.go
+++ b/internal/model/package.go
@@ -11,7 +11,7 @@ import (
 // Package is a struct containing all of the declarations found in a package directory
 type Package struct {
 	cfg          *config.Config
-	declarations map[string]Declaration // Dictionary of all the objects in the package, keyed by name
+	declarations map[string]Declaration // Dictionary of all objects in package, keyed by name
 	metadata     PackageMetadata
 	log          logr.Logger
 }

--- a/internal/model/package_test.go
+++ b/internal/model/package_test.go
@@ -88,6 +88,6 @@ func testdataPath(
 		t.Fatalf("Failed to get working directory: %v", err)
 	}
 
-	filepath := filepath.Join(wd, "testdata", filename)
-	return filepath
+	result := filepath.Join(wd, "testdata", filename)
+	return result
 }

--- a/internal/model/parser.go
+++ b/internal/model/parser.go
@@ -4,7 +4,7 @@ import "strings"
 
 // ParseComments iterates over the comments and returns the description and any commands that are
 // not part of the description
-// TODO: Add optional varidic "cleanup" functions to allow for more complex comment parsing and cleanup.
+// TODO: Add optional varidic "cleanup" functions to allow for more complex comment parsing/cleanup.
 func ParseComments(comments []string) ([]string, *Markers) {
 	description := make([]string, 0, len(comments))
 	commands := NewMarkers()

--- a/internal/packageloader/fileloader.go
+++ b/internal/packageloader/fileloader.go
@@ -83,7 +83,8 @@ func (loader *FileLoader) Load() error {
 				for _, spec := range gd.Specs {
 					// Try to create a value from this declaration
 					if enumValue, ok := model.TryNewEnumValue(spec); ok {
-						loader.values[enumValue.Kind()] = append(loader.values[enumValue.Kind()], enumValue)
+						kind := enumValue.Kind()
+						loader.values[kind] = append(loader.values[kind], enumValue)
 					}
 				}
 			}
@@ -139,7 +140,8 @@ func (loader *FileLoader) parseFile() (file *dst.File, failure error) {
 }
 
 func (loader *FileLoader) Declarations() []model.Declaration {
-	result := make([]model.Declaration, 0, len(loader.resources)+len(loader.objects)+len(loader.enums))
+	expectedDeclarations := len(loader.resources) + len(loader.objects) + len(loader.enums)
+	result := make([]model.Declaration, 0, expectedDeclarations)
 	for _, r := range loader.resources {
 		if loader.typeFilters.Filter(r.Name()) == typefilter.Included {
 			result = append(result, r)

--- a/internal/packageloader/fileloader.go
+++ b/internal/packageloader/fileloader.go
@@ -58,13 +58,12 @@ func (loader *FileLoader) Load() error {
 	loader.parseMetadata(file.Decs.End)
 
 	for _, decl := range file.Decls {
-
 		loader.parseMetadata(decl.Decorations().Start)
 		loader.parseMetadata(decl.Decorations().End)
 
 		if gd, ok := decl.(*dst.GenDecl); ok {
 			if gd.Tok == token.TYPE {
-
+				// Parse type declarations for objects and enums
 				comments := gd.Decs.Start.All()
 				for _, spec := range gd.Specs {
 					// Try to create an object from this declaration
@@ -81,7 +80,7 @@ func (loader *FileLoader) Load() error {
 
 			if gd.Tok == token.CONST {
 				for _, spec := range gd.Specs {
-					// Try to create a value from this declaration
+					// Parse constant declarations for enums
 					if enumValue, ok := model.TryNewEnumValue(spec); ok {
 						kind := enumValue.Kind()
 						loader.values[kind] = append(loader.values[kind], enumValue)

--- a/internal/packageloader/fileloader_test.go
+++ b/internal/packageloader/fileloader_test.go
@@ -93,6 +93,6 @@ func testdataPath(
 		t.Fatalf("Failed to get working directory: %v", err)
 	}
 
-	filepath := filepath.Join(wd, "testdata", filename)
-	return filepath
+	result := filepath.Join(wd, "testdata", filename)
+	return result
 }

--- a/internal/texteditor/text_editor.go
+++ b/internal/texteditor/text_editor.go
@@ -23,7 +23,7 @@ func NewEditor(cfg config.Editor) (*Editor, error) {
 	if cfg.Context != "" {
 		rx, err := regexp.Compile(cfg.Context)
 		if err != nil {
-			return nil, errors.Wrap(err, "editor unable to compile 'context':")
+			return nil, errors.Wrap(err, "compiling editor context")
 		}
 
 		result.contextRegexp = rx
@@ -32,7 +32,7 @@ func NewEditor(cfg config.Editor) (*Editor, error) {
 	if cfg.Search != "" {
 		rx, err := regexp.Compile(cfg.Search)
 		if err != nil {
-			return nil, errors.Wrap(err, "editor unable to compile 'search':")
+			return nil, errors.Wrap(err, "compiling editor search")
 		}
 
 		result.searchRegexp = rx


### PR DESCRIPTION
Enables the **revive** linter within **golangci-lint**, and addresses any issues found.

Non-default **revive** rules used include:

- dot-imports - allowing only gomega and ginko
- empty-lines
- import-shadowing
- indent-error-flow
- line-length-limit - set to 100 characters, but suppressed for certain tests