### PR TITLE
Add parent links to model

### DIFF
--- a/internal/model/declaration.go
+++ b/internal/model/declaration.go
@@ -7,6 +7,7 @@ type Declaration interface {
 	Kind() DeclarationType
 	Usage() []PropertyReference
 	SetUsage([]PropertyReference)
+	SetPackage(*Package)
 	Description() []string
 }
 

--- a/internal/model/enum.go
+++ b/internal/model/enum.go
@@ -8,6 +8,7 @@ type Enum struct {
 	description []string
 	values      []*EnumValue
 	base        TypeReference
+	pkg         *Package
 }
 
 func TryNewEnum(spec dst.Spec, comments []string) (*Enum, bool) {
@@ -51,6 +52,10 @@ func (e *Enum) Usage() []PropertyReference {
 
 func (e *Enum) SetUsage(usage []PropertyReference) {
 	e.usage = usage
+}
+
+func (e *Enum) SetPackage(pkg *Package) {
+	e.pkg = pkg
 }
 
 func (e *Enum) Description() []string {

--- a/internal/model/object.go
+++ b/internal/model/object.go
@@ -13,6 +13,7 @@ type Object struct {
 	properties  map[string]*Property
 	embeds      []*Property
 	description []string
+	pkg         *Package
 	usage       []PropertyReference // List of other properties that reference this object
 }
 
@@ -63,6 +64,10 @@ func (o *Object) Usage() []PropertyReference {
 
 func (o *Object) SetUsage(uses []PropertyReference) {
 	o.usage = uses
+}
+
+func (o *Object) SetPackage(p *Package) {
+	o.pkg = p
 }
 
 // Properties returns all the properties of the object, in alphabetical order.

--- a/internal/model/object.go
+++ b/internal/model/object.go
@@ -66,6 +66,10 @@ func (o *Object) SetUsage(uses []PropertyReference) {
 	o.usage = uses
 }
 
+func (o *Object) Package() *Package {
+	return o.pkg
+}
+
 func (o *Object) SetPackage(p *Package) {
 	o.pkg = p
 }

--- a/internal/model/object.go
+++ b/internal/model/object.go
@@ -110,7 +110,7 @@ func (o *Object) Description() []string {
 	return o.description
 }
 
-func (*Object) findProperties(structType *dst.StructType) map[string]*Property {
+func (o *Object) findProperties(structType *dst.StructType) map[string]*Property {
 	result := make(map[string]*Property)
 
 	// Iterate over the fields in the struct type and try to create a property for each one.
@@ -118,6 +118,7 @@ func (*Object) findProperties(structType *dst.StructType) map[string]*Property {
 		// A single field might contain multiple properties.
 		for _, name := range field.Names {
 			if property, ok := TryNewProperty(name.Name, field); ok {
+				property.setContainer(o)
 				result[property.Name] = property
 			}
 		}

--- a/internal/model/package.go
+++ b/internal/model/package.go
@@ -41,6 +41,7 @@ func NewPackage(
 	}
 
 	for _, d := range decl {
+		d.SetPackage(result)
 		result.declarations[d.Name()] = d
 	}
 

--- a/internal/model/property.go
+++ b/internal/model/property.go
@@ -13,6 +13,7 @@ type Property struct {
 	Type        TypeReference
 	description []string
 	required    string
+	container   PropertyContainer
 }
 
 func TryNewProperty(name string, field *dst.Field) (*Property, bool) {
@@ -84,4 +85,8 @@ func (*Property) tryParseNameFromTag(
 	}
 
 	return "", false
+}
+
+func (p *Property) setContainer(container PropertyContainer) {
+	p.container = container
 }

--- a/internal/model/property_container.go
+++ b/internal/model/property_container.go
@@ -2,4 +2,5 @@ package model
 
 type PropertyContainer interface {
 	Properties() []*Property
+	Package() *Package
 }

--- a/internal/model/resource.go
+++ b/internal/model/resource.go
@@ -25,13 +25,23 @@ func TryNewResource(object *Object) (*Resource, bool) {
 		return nil, false
 	}
 
-	return &Resource{
+	result := &Resource{
 		Object: *object,
 		Spec:   spec,
 		Status: status,
-	}, true
+	}
+
+	result.takePropertyOwnership()
+
+	return result, true
 }
 
 func (*Resource) Kind() DeclarationType {
 	return ResourceDeclaration
+}
+
+func (r *Resource) takePropertyOwnership() {
+	for _, p := range r.properties {
+		p.setContainer(r)
+	}
 }


### PR DESCRIPTION
Add links to the object model allowing code navigation from a property to its containing object, and from any declaration to the package.

These links are a prerequisite for adding features where property defaults are driven at the package level.