### PR TITLE
Introduce the nilaway linter

### DIFF
--- a/.custom-gcl.yml
+++ b/.custom-gcl.yml
@@ -1,4 +1,6 @@
 version: v1.61.0
+name: golangci-lint-custom
+destination: ./tools
 plugins:
   - module: "go.uber.org/nilaway"
     import: "go.uber.org/nilaway/cmd/gclplugin"

--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,10 @@ go.work
 
 .idea
 .vscode
-tools/
+tools/custom-gcl
+tools/gofumpt
+tools/golangci-lint
+tools/go-testreport
+tools/gremlins
+tools/oh-my-posh
+tools/task

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 go.work
 
 .idea
+.task
 .vscode
 tools/custom-gcl
 tools/gofumpt

--- a/.gitignore
+++ b/.gitignore
@@ -23,10 +23,4 @@ go.work
 .idea
 .task
 .vscode
-tools/custom-gcl
-tools/gofumpt
-tools/golangci-lint
-tools/go-testreport
-tools/gremlins
-tools/oh-my-posh
-tools/task
+tools

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  deadline: 5m
+  timeout: 5m
   allow-parallel-runners: true
 
 issues:
@@ -24,6 +24,7 @@ linters:
     - maintidx
     - misspell
     - nestif
+    - nilaway
     - nilerr
     - nlreturn
     - nolintlint
@@ -99,9 +100,15 @@ linters-settings:
         arguments: [100]
       - name: unhandled-error
         disabled: true
-
   unused:
     generated-is-used: true
-
   wsl:
     allow-cuddle-declarations: true
+  custom:
+    nilaway:
+      type: "module"
+      description: Static analysis tool to detect potential nil panics in Go code.
+      settings:
+        # Settings must be a "map from string to string" to mimic command line flags: the keys are
+        # flag names and the values are the values to the particular flags.
+        include-pkgs: "github.com/theunrepentantgeek/crddoc, github.com/onsi/gomega"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -5,7 +5,7 @@ version: "3"
 vars:
   TOOLS_DIR: '{{ list .ROOT_DIR "tools" | join "/" | osClean }}'
   SAMPLES_DIR: '{{ list .ROOT_DIR "samples" | join "/" | osClean }}'
-  GOLANGCI_CUSTOM: '{{ list .TOOLS_DIR "custom-gcl" | join "/" | osClean }}'
+  GOLANGCI_CUSTOM: '{{ list .TOOLS_DIR "golangci-lint-custom" | join "/" | osClean }}'
 
 run: once
 
@@ -41,7 +41,7 @@ tasks:
     deps:
       - golangci-lint-custom
     cmds:
-      - "{{.GOLANGCI_CUSTOM}} run"
+      - "{{.GOLANGCI_CUSTOM}} run --verbose"
 
   ci:
     desc: Run continuous integration tasks
@@ -122,16 +122,11 @@ tasks:
     cmds:
       - cmd: echo "Building custom golangci-lint"
         silent: true
-      - pwd
-      - echo {{.TOOLS_DIR}}
-      - echo {{.SAMPLES_DIR}}
-      - echo {{.GOLANGCI_CUSTOM}}
       - golangci-lint custom
-    dir: "{{.TOOLS_DIR}}"
     # Skip if we've already built the custom golangci-lint
     status:
       # Don't need to rebuild the custom tool if it exists
-      - test -f {{.TOOLS_DIR}}/custom-gcl
+      - test -f {{.TOOLS_DIR}}/golangci-lint-custom
     sources:
       - .custom-gcl.yml
-      - ../.golangci.yml
+      - .golangci.yml

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -38,8 +38,10 @@ tasks:
 
   lint:
     desc: Run golangci-lint to check for linting issues
+    deps:
+      - golangci-lint-custom
     cmds:
-      - golangci-lint run
+      - "{{.GOLANGCI_CUSTOM}} run"
 
   ci:
     desc: Run continuous integration tasks

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,7 +3,9 @@
 version: "3"
 
 vars:
+  TOOLS_DIR: '{{ list .ROOT_DIR "tools" | join "/" | osClean }}'
   SAMPLES_DIR: '{{ list .ROOT_DIR "samples" | join "/" | osClean }}'
+  GOLANGCI_CUSTOM: '{{ list .TOOLS_DIR "custom-gcl" | join "/" | osClean }}'
 
 run: once
 
@@ -111,3 +113,23 @@ tasks:
     desc: "Use gremlins to check the quality of our tests"
     cmds:
       - gremlins unleash ./internal
+
+  # We use a custom golangci-lint with the nilaway module included,
+  # this target builds this if needed
+  golangci-lint-custom:
+    cmds:
+      - cmd: echo "Building custom golangci-lint"
+        silent: true
+      - pwd
+      - echo {{.TOOLS_DIR}}
+      - echo {{.SAMPLES_DIR}}
+      - echo {{.GOLANGCI_CUSTOM}}
+      - golangci-lint custom
+    dir: "{{.TOOLS_DIR}}"
+    # Skip if we've already built the custom golangci-lint
+    status:
+      # Don't need to rebuild the custom tool if it exists
+      - test -f {{.TOOLS_DIR}}/custom-gcl
+    sources:
+      - .custom-gcl.yml
+      - ../.golangci.yml

--- a/cmd/document-package.go
+++ b/cmd/document-package.go
@@ -91,7 +91,7 @@ func documentPackage(
 func loadConfig(
 	options *documentPackageOptions,
 ) (*config.Config, error) {
-	cfg := config.Default()
+	cfg := config.Standard()
 
 	// If we have a config file specified, load it
 	if options.configPath != nil && *options.configPath != "" {

--- a/cmd/export-configuration.go
+++ b/cmd/export-configuration.go
@@ -41,8 +41,8 @@ func exportConfiguration(
 		return errors.New("too many export filenames supplied")
 	}
 
-	// Create our default configuration
-	cfg := config.Default()
+	// Create our standard configuration
+	cfg := config.Standard()
 
 	// Save the configuration to a file as yaml
 	file := args[0]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,9 +27,9 @@ type Config struct {
 	TemplatePath string `yaml:"templatePath"`
 }
 
-// Default returns the default configuration, as a basis for loading
+// Standard returns the standard, as a basis for loading other configuration,
 // or for export.
-func Default() *Config {
+func Standard() *Config {
 	return &Config{
 		PrettyPrint: true,
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,12 +3,12 @@ package config
 import (
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 )
 
 func TestConfig_Validate_WhenFilterInvalid_ReturnsError(t *testing.T) {
 	t.Parallel()
-	g := gomega.NewWithT(t)
+	g := NewGomegaWithT(t)
 
 	// Arrange
 	c := &Config{
@@ -24,5 +24,5 @@ func TestConfig_Validate_WhenFilterInvalid_ReturnsError(t *testing.T) {
 	err := c.Validate()
 
 	// Assert
-	g.Expect(err).To(gomega.HaveOccurred())
+	g.Expect(err).To(HaveOccurred())
 }

--- a/internal/config/editor_test.go
+++ b/internal/config/editor_test.go
@@ -3,13 +3,13 @@ package config
 import (
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 )
 
 func TestEditor_Validate_WhenContextIsInvalidRegex_ReturnsExpectedError(t *testing.T) {
 	t.Parallel()
 
-	g := gomega.NewWithT(t)
+	g := NewGomegaWithT(t)
 
 	// Arrange
 	edit := &Editor{
@@ -21,14 +21,14 @@ func TestEditor_Validate_WhenContextIsInvalidRegex_ReturnsExpectedError(t *testi
 	err := edit.Validate()
 
 	// Assert
-	g.Expect(err).To(gomega.HaveOccurred())
 	g.Expect(err.Error()).To(gomega.ContainSubstring("compiling editor context expression"))
+	g.Expect(err).To(HaveOccurred())
 }
 
 func TestEditor_WhenSearchIsMissing_ReturnsExpectedError(t *testing.T) {
 	t.Parallel()
 
-	g := gomega.NewWithT(t)
+	g := NewGomegaWithT(t)
 
 	// Arrange
 	edit := &Editor{}
@@ -37,14 +37,14 @@ func TestEditor_WhenSearchIsMissing_ReturnsExpectedError(t *testing.T) {
 	err := edit.Validate()
 
 	// Assert
-	g.Expect(err).To(gomega.HaveOccurred())
 	g.Expect(err.Error()).To(gomega.ContainSubstring("editor search expression may not be empty"))
+	g.Expect(err).To(HaveOccurred())
 }
 
 func TestEditor_Validate_WhenSearchIsInvalidRegex_ReturnsExpectedError(t *testing.T) {
 	t.Parallel()
 
-	g := gomega.NewWithT(t)
+	g := NewGomegaWithT(t)
 
 	// Arrange
 	edit := &Editor{
@@ -55,6 +55,6 @@ func TestEditor_Validate_WhenSearchIsInvalidRegex_ReturnsExpectedError(t *testin
 	err := edit.Validate()
 
 	// Assert
-	g.Expect(err).To(gomega.HaveOccurred())
 	g.Expect(err.Error()).To(gomega.ContainSubstring("compiling editor search expression"))
+	g.Expect(err).To(HaveOccurred())
 }

--- a/internal/config/editor_test.go
+++ b/internal/config/editor_test.go
@@ -21,8 +21,8 @@ func TestEditor_Validate_WhenContextIsInvalidRegex_ReturnsExpectedError(t *testi
 	err := edit.Validate()
 
 	// Assert
-	g.Expect(err.Error()).To(gomega.ContainSubstring("compiling editor context expression"))
 	g.Expect(err).To(HaveOccurred())
+	g.Expect(err).To(MatchError(ContainSubstring("compiling editor context expression")))
 }
 
 func TestEditor_WhenSearchIsMissing_ReturnsExpectedError(t *testing.T) {
@@ -37,8 +37,8 @@ func TestEditor_WhenSearchIsMissing_ReturnsExpectedError(t *testing.T) {
 	err := edit.Validate()
 
 	// Assert
-	g.Expect(err.Error()).To(gomega.ContainSubstring("editor search expression may not be empty"))
 	g.Expect(err).To(HaveOccurred())
+	g.Expect(err).To(MatchError(ContainSubstring("editor search expression may not be empty")))
 }
 
 func TestEditor_Validate_WhenSearchIsInvalidRegex_ReturnsExpectedError(t *testing.T) {
@@ -55,6 +55,6 @@ func TestEditor_Validate_WhenSearchIsInvalidRegex_ReturnsExpectedError(t *testin
 	err := edit.Validate()
 
 	// Assert
-	g.Expect(err.Error()).To(gomega.ContainSubstring("compiling editor search expression"))
 	g.Expect(err).To(HaveOccurred())
+	g.Expect(err).To(MatchError(ContainSubstring("compiling editor search expression")))
 }

--- a/internal/config/filter_test.go
+++ b/internal/config/filter_test.go
@@ -17,8 +17,8 @@ func TestFilter_Validate_WhenBlank_ReturnsError(t *testing.T) {
 	err := f.validate()
 
 	// Assert
-	g.Expect(err).To(gomega.HaveOccurred())
-	g.Expect(err.Error()).To(gomega.ContainSubstring("must specify either"))
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(err).To(MatchError(ContainSubstring("must specify either")))
 }
 
 func TestFilter_Validate_WhenBothIncludeAndExcludeSpecified_ReturnsError(t *testing.T) {
@@ -35,6 +35,6 @@ func TestFilter_Validate_WhenBothIncludeAndExcludeSpecified_ReturnsError(t *test
 	err := f.validate()
 
 	// Assert
-	g.Expect(err.Error()).To(gomega.ContainSubstring("cannot specify both"))
 	g.Expect(err).To(HaveOccurred())
+	g.Expect(err).To(MatchError(ContainSubstring("cannot specify both")))
 }

--- a/internal/config/filter_test.go
+++ b/internal/config/filter_test.go
@@ -3,12 +3,12 @@ package config
 import (
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 )
 
 func TestFilter_Validate_WhenBlank_ReturnsError(t *testing.T) {
 	t.Parallel()
-	g := gomega.NewWithT(t)
+	g := NewGomegaWithT(t)
 
 	// Arrange
 	f := &Filter{}
@@ -23,7 +23,7 @@ func TestFilter_Validate_WhenBlank_ReturnsError(t *testing.T) {
 
 func TestFilter_Validate_WhenBothIncludeAndExcludeSpecified_ReturnsError(t *testing.T) {
 	t.Parallel()
-	g := gomega.NewWithT(t)
+	g := NewGomegaWithT(t)
 
 	// Arrange
 	f := &Filter{
@@ -35,6 +35,6 @@ func TestFilter_Validate_WhenBothIncludeAndExcludeSpecified_ReturnsError(t *test
 	err := f.validate()
 
 	// Assert
-	g.Expect(err).To(gomega.HaveOccurred())
 	g.Expect(err.Error()).To(gomega.ContainSubstring("cannot specify both"))
+	g.Expect(err).To(HaveOccurred())
 }

--- a/internal/model/markers_test.go
+++ b/internal/model/markers_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 
 	"github.com/theunrepentantgeek/crddoc/internal/model"
 )
@@ -29,13 +29,13 @@ func TestMarkers_Lookup_ReturnsExpectedValue(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
-			g := gomega.NewWithT(t)
+			g := NewGomegaWithT(t)
 
 			path := strings.Split(c.lookup, ":")
 			actual, ok := markers.Lookup(path...)
 
-			g.Expect(ok).To(gomega.Equal(c.expected != ""))
-			g.Expect(actual.Value()).To(gomega.Equal(c.expected))
+			g.Expect(ok).To(Equal(c.expected != ""))
+			g.Expect(actual.Value()).To(Equal(c.expected))
 		})
 	}
 }
@@ -72,12 +72,12 @@ func TestMarkers_Exists_ReturnsExpectedValue(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
-			g := gomega.NewWithT(t)
+			g := NewGomegaWithT(t)
 
 			path := strings.Split(c.lookup, ":")
 			found := markers.Exists(path...)
 
-			g.Expect(found).To(gomega.Equal(c.expected))
+			g.Expect(found).To(Equal(c.expected))
 		})
 	}
 }

--- a/internal/model/markervalue_test.go
+++ b/internal/model/markervalue_test.go
@@ -104,10 +104,9 @@ func TestMarkerValue_WhenUpdatedWithDifferentValue_ReturnsError(t *testing.T) {
 
 	err = value.Update(testMarkers)
 	g.Expect(err).To(Not(BeNil()))
-
-	g.Expect(err.Error()).To(ContainSubstring("does not match"))
-	g.Expect(err.Error()).To(ContainSubstring("alertsmanagement.azure.com"))
-	g.Expect(err.Error()).To(ContainSubstring("network.azure.com"))
+	g.Expect(err).To(MatchError(ContainSubstring("does not match")))
+	g.Expect(err).To(MatchError(ContainSubstring("alertsmanagement.azure.com")))
+	g.Expect(err).To(MatchError(ContainSubstring("network.azure.com")))
 }
 
 //nolint:funlen, revive // excessive length is acceptable for tests
@@ -164,7 +163,7 @@ func TestMarkerValueMerge_givenValue_ReturnsExpectedResult(t *testing.T) {
 				g.Expect(err).To(Not(BeNil()))
 
 				for _, s := range c.expectedErrorSubstrings {
-					g.Expect(err.Error()).To(ContainSubstring(s))
+					g.Expect(err).To(MatchError(ContainSubstring(s)))
 				}
 			} else {
 				g.Expect(err).To(BeNil())

--- a/internal/model/object_test.go
+++ b/internal/model/object_test.go
@@ -49,13 +49,19 @@ func TestObject_Property_ReturnsExpectedContent(t *testing.T) {
 	g.Expect(ok).To(BeTrue())
 
 	for n, c := range cases {
-		prop, ok := obj.Property(c.propertyName)
-		g.Expect(ok).To(Equal(c.expectedExists), "case %s", n)
+		t.Run(n, func(t *testing.T) {
+			t.Parallel()
 
-		if c.expectedExists {
-			g.Expect(prop).NotTo(BeNil(), "case %s", n)
-			g.Expect(prop.Name).To(Equal(c.propertyName), "case %s", n)
-			g.Expect(prop.DeclaredOn).To(Equal(obj), "case %s", n)
-		}
+			g := NewGomegaWithT(t)
+
+			prop, ok := obj.Property(c.propertyName)
+			g.Expect(ok).To(Equal(c.expectedExists))
+
+			if c.expectedExists {
+				g.Expect(prop).NotTo(BeNil())
+				g.Expect(prop.Name).To(Equal(c.propertyName))
+				g.Expect(prop.DeclaredOn).To(Equal(obj))
+			}
+		})
 	}
 }

--- a/internal/texteditor/text_editor_test.go
+++ b/internal/texteditor/text_editor_test.go
@@ -62,7 +62,7 @@ func TestEditor_Replace_ReturnsExpectedResult(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
-			g := NewWithT(t)
+			g := NewGomegaWithT(t)
 
 			actual := c.editor.Replace(c.input)
 			g.Expect(actual).To(Equal(c.expected))

--- a/internal/typefilter/type_filter_list_test.go
+++ b/internal/typefilter/type_filter_list_test.go
@@ -3,14 +3,14 @@ package typefilter
 import (
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 
 	"github.com/theunrepentantgeek/crddoc/internal/config"
 )
 
 func TestTypeFilterList_Filter_WhenIncludeFilterMatches_ReturnsInclude(t *testing.T) {
 	t.Parallel()
-	g := gomega.NewWithT(t)
+	g := NewGomegaWithT(t)
 
 	// Arrange
 	cfg := &config.Config{
@@ -26,12 +26,12 @@ func TestTypeFilterList_Filter_WhenIncludeFilterMatches_ReturnsInclude(t *testin
 	result := filters.Filter("12345")
 
 	// Assert
-	g.Expect(result).To(gomega.Equal(Included))
+	g.Expect(result).To(Equal(Included))
 }
 
 func TestTypeFilterList_Filter_WhenExcludeMatchesBeforeInclude_ReturnsExclude(t *testing.T) {
 	t.Parallel()
-	g := gomega.NewWithT(t)
+	g := NewGomegaWithT(t)
 
 	// Arrange
 	cfg := &config.Config{
@@ -50,12 +50,12 @@ func TestTypeFilterList_Filter_WhenExcludeMatchesBeforeInclude_ReturnsExclude(t 
 	result := filters.Filter("Foot")
 
 	// Assert
-	g.Expect(result).To(gomega.Equal(Excluded))
+	g.Expect(result).To(Equal(Excluded))
 }
 
 func TestTypeFilterList_Filter_WhenIncludeMatchesBeforeExclude_ReturnsInclude(t *testing.T) {
 	t.Parallel()
-	g := gomega.NewWithT(t)
+	g := NewGomegaWithT(t)
 
 	// Arrange
 	cfg := &config.Config{
@@ -74,5 +74,5 @@ func TestTypeFilterList_Filter_WhenIncludeMatchesBeforeExclude_ReturnsInclude(t 
 	result := filters.Filter("12345")
 
 	// Assert
-	g.Expect(result).To(gomega.Equal(Included))
+	g.Expect(result).To(Equal(Included))
 }

--- a/internal/typefilter/type_filter_test.go
+++ b/internal/typefilter/type_filter_test.go
@@ -3,14 +3,14 @@ package typefilter
 import (
 	"testing"
 
-	"github.com/onsi/gomega"
+	. "github.com/onsi/gomega"
 
 	"github.com/theunrepentantgeek/crddoc/internal/config"
 )
 
 func TestTypeFilter_Applies_WhenExcludeMatchedExactCase_ReturnsExcluded(t *testing.T) {
 	t.Parallel()
-	g := gomega.NewWithT(t)
+	g := NewGomegaWithT(t)
 
 	// Arrange
 	cfg := &config.Filter{
@@ -22,12 +22,12 @@ func TestTypeFilter_Applies_WhenExcludeMatchedExactCase_ReturnsExcluded(t *testi
 	result := f.Applies("Foot")
 
 	// Assert
-	g.Expect(result).To(gomega.Equal(Excluded))
+	g.Expect(result).To(Equal(Excluded))
 }
 
 func TestTypeFilter_Applies_WhenExcludeMatchedDifferentCase_ReturnsExcluded(t *testing.T) {
 	t.Parallel()
-	g := gomega.NewWithT(t)
+	g := NewGomegaWithT(t)
 
 	// Arrange
 	cfg := &config.Filter{
@@ -39,12 +39,12 @@ func TestTypeFilter_Applies_WhenExcludeMatchedDifferentCase_ReturnsExcluded(t *t
 	result := f.Applies("foot")
 
 	// Assert
-	g.Expect(result).To(gomega.Equal(Excluded))
+	g.Expect(result).To(Equal(Excluded))
 }
 
 func TestTypeFilter_Applies_WhenExcludedUnmatched_ReturnsNone(t *testing.T) {
 	t.Parallel()
-	g := gomega.NewWithT(t)
+	g := NewGomegaWithT(t)
 
 	// Arrange
 	cfg := &config.Filter{
@@ -56,12 +56,12 @@ func TestTypeFilter_Applies_WhenExcludedUnmatched_ReturnsNone(t *testing.T) {
 	result := f.Applies("abcde")
 
 	// Assert
-	g.Expect(result).To(gomega.Equal(Skipped))
+	g.Expect(result).To(Equal(Skipped))
 }
 
 func TestTypeFilter_Applies_WhenIncludedMatchedExactCase_ReturnsIncluded(t *testing.T) {
 	t.Parallel()
-	g := gomega.NewWithT(t)
+	g := NewGomegaWithT(t)
 
 	// Arrange
 	cfg := &config.Filter{
@@ -73,12 +73,12 @@ func TestTypeFilter_Applies_WhenIncludedMatchedExactCase_ReturnsIncluded(t *test
 	result := f.Applies("Foot")
 
 	// Assert
-	g.Expect(result).To(gomega.Equal(Included))
+	g.Expect(result).To(Equal(Included))
 }
 
 func TestTypeFilter_Applies_WhenIncludedMatchedDifferentCase_ReturnsIncluded(t *testing.T) {
 	t.Parallel()
-	g := gomega.NewWithT(t)
+	g := NewGomegaWithT(t)
 
 	// Arrange
 	cfg := &config.Filter{
@@ -90,12 +90,12 @@ func TestTypeFilter_Applies_WhenIncludedMatchedDifferentCase_ReturnsIncluded(t *
 	result := f.Applies("foot")
 
 	// Assert
-	g.Expect(result).To(gomega.Equal(Included))
+	g.Expect(result).To(Equal(Included))
 }
 
 func TestTypeFilter_Applies_WhenIncludedUnmatched_ReturnsNone(t *testing.T) {
 	t.Parallel()
-	g := gomega.NewWithT(t)
+	g := NewGomegaWithT(t)
 
 	// Arrange
 	cfg := &config.Filter{
@@ -107,5 +107,5 @@ func TestTypeFilter_Applies_WhenIncludedUnmatched_ReturnsNone(t *testing.T) {
 	result := f.Applies("Arm")
 
 	// Assert
-	g.Expect(result).To(gomega.Equal(Skipped))
+	g.Expect(result).To(Equal(Skipped))
 }

--- a/tools/.custom-gcl.yml
+++ b/tools/.custom-gcl.yml
@@ -1,0 +1,5 @@
+version: v1.61.0
+plugins:
+  - module: "go.uber.org/nilaway"
+    import: "go.uber.org/nilaway/cmd/gclplugin"
+    version: latest # Or a fixed version for reproducible builds.


### PR DESCRIPTION
It's [now possible](https://github.com/uber-go/nilaway?tab=readme-ov-file#golangci-lint--v1570) to easily integrate [nilaway](https://github.com/uber-go/nilaway) into [golangci-lint](https://golangci-lint.run/), so I'm hooking it in to see what value it provides.

This has required a minor refactoring of some tests to avoid a few false positives.