### PR TITLE
Update use of go-testreport

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -112,3 +112,4 @@ linters-settings:
         # Settings must be a "map from string to string" to mimic command line flags: the keys are
         # flag names and the values are the values to the particular flags.
         include-pkgs: "github.com/theunrepentantgeek/crddoc, github.com/onsi/gomega"
+        #include-pkgs: ""

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -32,7 +32,7 @@ tasks:
     deps:
       - build
     cmds:
-      - go test ./... -json | go-testreport {{.REPORT}}
+      - go test ./... -json | go-testreport -output {{.REPORT}}
     vars:
       REPORT: '{{.GITHUB_STEP_SUMMARY | default "test-report.md" }}'
 

--- a/internal/model/object_test.go
+++ b/internal/model/object_test.go
@@ -38,9 +38,8 @@ func TestObject_Property_ReturnsExpectedContent(t *testing.T) {
 	loader := packageloader.New(cfg, logr.Discard())
 
 	pkg, err := loader.LoadFile(testdataPath(t, "person_types.go"))
-	if err != nil {
-		t.Fatalf("Failed to load file: %v", err)
-	}
+	g.Expect(err).To(Succeed())
+	g.Expect(pkg).NotTo(BeNil())
 
 	dec, ok := pkg.Declaration("PersonResourceSpec")
 	g.Expect(ok).To(BeTrue())

--- a/internal/model/package.go
+++ b/internal/model/package.go
@@ -56,6 +56,10 @@ func (p *Package) Name() string {
 }
 
 func (p *Package) Declarations(order Order) []Declaration {
+	if p == nil || p.declarations == nil {
+		return nil
+	}
+
 	result := maps.Values(p.declarations)
 
 	// Sort the declarations as specified
@@ -73,6 +77,10 @@ func (p *Package) Declarations(order Order) []Declaration {
 
 // Declaration returns the declaration with the given name, if found.
 func (p *Package) Declaration(name string) (Declaration, bool) {
+	if p == nil || p.declarations == nil {
+		return nil, false
+	}
+
 	dec, ok := p.declarations[name]
 	if !ok {
 		return nil, false

--- a/internal/model/package_test.go
+++ b/internal/model/package_test.go
@@ -23,10 +23,8 @@ func TestPackage_LoadFile_LoadsExpectedContent(t *testing.T) {
 	loader := packageloader.New(cfg, logr.Discard())
 
 	pkg, err := loader.LoadFile(testdataPath(t, "person_types.go"))
-	if err != nil {
-		t.Fatalf("Failed to load file: %v", err)
-	}
 
+	g.Expect(err).To(Succeed())
 	g.Expect(len(pkg.Declarations(model.OrderAlphabetical))).To(Equal(4))
 }
 
@@ -43,12 +41,15 @@ func TestPackage_Objects_ReturnsExpectedSequence(t *testing.T) {
 	}
 
 	declarations := pkg.Declarations(model.OrderAlphabetical)
+	g.Expect(declarations).NotTo(BeNil())
 	g.Expect(len(declarations)).To(Equal(4))
 
-	g.Expect(declarations[0].Name()).To(Equal("PersonReference"))
-	g.Expect(declarations[1].Name()).To(Equal("PersonResource"))
-	g.Expect(declarations[2].Name()).To(Equal("PersonResourceSpec"))
-	g.Expect(declarations[3].Name()).To(Equal("PersonResourceStatus"))
+	if declarations != nil {
+		g.Expect(declarations[0].Name()).To(Equal("PersonReference"))
+		g.Expect(declarations[1].Name()).To(Equal("PersonResource"))
+		g.Expect(declarations[2].Name()).To(Equal("PersonResourceSpec"))
+		g.Expect(declarations[3].Name()).To(Equal("PersonResourceStatus"))
+	}
 }
 
 func TestPackage_Declaration_ReturnsExpectedObjects(t *testing.T) {


### PR DESCRIPTION
The latest version of `go-testreport` changes the available command line parameters, resulting in our builds not working.

Also addresses a couple new nilaway warnings.