### PR TITLE
Introduce PackageBuilder to simplify construction

### DIFF
--- a/internal/model/package.go
+++ b/internal/model/package.go
@@ -19,56 +19,12 @@ type Package struct {
 	log          logr.Logger
 }
 
-// PackageBuilder is a builder for Package instances.
-type PackageBuilder struct {
-	Declarations []Declaration
-	Metadata     *PackageMarkers
-	Config       *config.Config
-	Log          logr.Logger
-}
-
-// Build creates a new Package from the builder.
-func (b *PackageBuilder) Build() *Package {
-	result := &Package{
-		cfg:          b.Config,
-		declarations: make(map[string]Declaration, len(b.Declarations)),
-		ranks:        make(map[string]int, len(b.Declarations)),
-		metadata:     b.Metadata,
-		log:          b.Log,
-	}
-
-	for _, d := range b.Declarations {
-		d.SetPackage(result)
-		result.declarations[d.Name()] = d
-	}
-
-	result.catalogCrossReferences()
-	result.calculateRanks()
-
-	return result
-}
-
 type Order string
 
 const (
 	OrderAlphabetical = "alphabetical"
 	OrderRanked       = "ranked"
 )
-
-func NewPackage(
-	decl []Declaration,
-	metadata *PackageMarkers,
-	cfg *config.Config,
-	log logr.Logger,
-) *Package {
-	builder := &PackageBuilder{
-		Declarations: decl,
-		Metadata:     metadata,
-		Config:       cfg,
-		Log:          log,
-	}
-	return builder.Build()
-}
 
 func (p *Package) Name() string {
 	return p.metadata.Name

--- a/internal/model/package_builder.go
+++ b/internal/model/package_builder.go
@@ -7,9 +7,9 @@ import (
 
 // PackageBuilder is a builder for Package instances.
 type PackageBuilder struct {
-	Resources []Declaration
-	Objects   []Declaration
-	Enums     []Declaration
+	Resources []*Resource
+	Objects   []*Object
+	Enums     []*Enum
 	Metadata  *PackageMarkers
 	Config    *config.Config
 	Log       logr.Logger

--- a/internal/model/package_builder.go
+++ b/internal/model/package_builder.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"github.com/go-logr/logr"
+
 	"github.com/theunrepentantgeek/crddoc/internal/config"
 )
 

--- a/internal/model/package_builder.go
+++ b/internal/model/package_builder.go
@@ -1,0 +1,53 @@
+package model
+
+import (
+	"github.com/go-logr/logr"
+	"github.com/theunrepentantgeek/crddoc/internal/config"
+)
+
+// PackageBuilder is a builder for Package instances.
+type PackageBuilder struct {
+	Resources []Declaration
+	Objects   []Declaration
+	Enums     []Declaration
+	Metadata  *PackageMarkers
+	Config    *config.Config
+	Log       logr.Logger
+}
+
+// Build creates a new Package from the builder.
+func (b *PackageBuilder) Build() *Package {
+	// Calculate total size for all declarations
+	totalDeclarations := len(b.Resources) + len(b.Objects) + len(b.Enums)
+
+	result := &Package{
+		cfg:          b.Config,
+		declarations: make(map[string]Declaration, totalDeclarations),
+		ranks:        make(map[string]int, totalDeclarations),
+		metadata:     b.Metadata,
+		log:          b.Log,
+	}
+
+	// Add all resources
+	for _, d := range b.Resources {
+		d.SetPackage(result)
+		result.declarations[d.Name()] = d
+	}
+
+	// Add all objects
+	for _, d := range b.Objects {
+		d.SetPackage(result)
+		result.declarations[d.Name()] = d
+	}
+
+	// Add all enums
+	for _, d := range b.Enums {
+		d.SetPackage(result)
+		result.declarations[d.Name()] = d
+	}
+
+	result.catalogCrossReferences()
+	result.calculateRanks()
+
+	return result
+}

--- a/internal/packageloader/fileloader.go
+++ b/internal/packageloader/fileloader.go
@@ -5,7 +5,6 @@ import (
 	"maps"
 	"os"
 	"path/filepath"
-	"slices"
 
 	"github.com/dave/dst"
 	"github.com/dave/dst/decorator"
@@ -195,19 +194,23 @@ func (loader *FileLoader) parseFile() (file *dst.File, failure error) {
 	return file, nil
 }
 
-func (loader *FileLoader) Declarations() []model.Declaration {
-	resources := filterDeclarations(loader.resources, loader.typeFilters)
-	objects := filterDeclarations(loader.objects, loader.typeFilters)
-	enums := filterDeclarations(loader.enums, loader.typeFilters)
+func (loader *FileLoader) Resources() []*model.Resource {
+	return filterDeclarations(loader.resources, loader.typeFilters)
+}
 
-	return slices.Concat(resources, objects, enums)
+func (loader *FileLoader) Objects() []*model.Object {
+	return filterDeclarations(loader.objects, loader.typeFilters)
+}
+
+func (loader *FileLoader) Enums() []*model.Enum {
+	return filterDeclarations(loader.enums, loader.typeFilters)
 }
 
 func filterDeclarations[D model.Declaration](
 	decls map[string]D,
 	typeFilters *typefilter.List,
-) []model.Declaration {
-	result := make([]model.Declaration, 0, len(decls))
+) []D {
+	result := make([]D, 0, len(decls))
 
 	for n, d := range decls {
 		if typeFilters.Filter(n) == typefilter.Included {

--- a/internal/packageloader/packageloader.go
+++ b/internal/packageloader/packageloader.go
@@ -191,7 +191,13 @@ func (loader *PackageLoader) collectDeclarations(
 		}
 	}
 
-	pkg := model.NewPackage(declarations, metadata, loader.cfg, loader.log)
+	builder := &model.PackageBuilder{
+		Declarations: declarations,
+		Metadata:     metadata,
+		Config:       loader.cfg,
+		Log:          loader.log,
+	}
+	pkg := builder.Build()
 	packages <- pkg
 }
 

--- a/internal/packageloader/packageloader.go
+++ b/internal/packageloader/packageloader.go
@@ -178,26 +178,18 @@ func (loader *PackageLoader) collectDeclarations(
 ) {
 	metadata := loader.readMetadata(folder)
 
-	// Initialize separate slices for each type of declaration
-	var resources, objects, enums []model.Declaration
+	// Initialize slices for each type of declaration
+	var resources []*model.Resource
+	var objects []*model.Object
+	var enums []*model.Enum
 
 	for fl := range loadedFiles {
 		loader.log.V(3).Info("Collecting declarations", "file", fl.name)
 
-		// Get all declarations from the file
-		decls := fl.Declarations()
-
-		// Sort the declarations by type
-		for _, d := range decls {
-			switch d.Kind() {
-			case model.ResourceDeclaration:
-				resources = append(resources, d)
-			case model.ObjectDeclaration:
-				objects = append(objects, d)
-			case model.EnumDeclaration:
-				enums = append(enums, d)
-			}
-		}
+		// Get declarations by type directly
+		resources = append(resources, fl.Resources()...)
+		objects = append(objects, fl.Objects()...)
+		enums = append(enums, fl.Enums()...)
 
 		if err := metadata.Merge(fl.PackageMarkers()); err != nil {
 			loader.log.Error(err, "Failed to merge package markers")


### PR DESCRIPTION
Replaces the complex constructor for PackageBuilder with a new `PackageBuilder` type to simplify the construction of `Package` instances.
