### PR TITLE
Simplify Declaration interface

### DIFF
--- a/internal/model/declaration.go
+++ b/internal/model/declaration.go
@@ -6,9 +6,7 @@ type Declaration interface {
 	ID() string
 	Kind() DeclarationType
 	Usage() []PropertyReference
-	SetUsage(refs []PropertyReference)
 	Package() *Package
-	SetPackage(pkg *Package)
 	Description() []string
 }
 

--- a/internal/model/package.go
+++ b/internal/model/package.go
@@ -1,6 +1,8 @@
 package model
 
 import (
+	"iter"
+	"maps"
 	"slices"
 	"strings"
 
@@ -36,26 +38,11 @@ func (p *Package) Declarations(order Order) []Declaration {
 		return nil
 	}
 
-	// Calculate total size for all declarations
-	totalDeclarations := len(p.resources) + len(p.objects) + len(p.enums)
-
 	// Collect all declarations into a single slice
-	allDeclarations := make([]Declaration, 0, totalDeclarations)
-
-	// Add resources
-	for _, res := range p.resources {
-		allDeclarations = append(allDeclarations, res)
-	}
-
-	// Add objects
-	for _, obj := range p.objects {
-		allDeclarations = append(allDeclarations, obj)
-	}
-
-	// Add enums
-	for _, enum := range p.enums {
-		allDeclarations = append(allDeclarations, enum)
-	}
+	allDeclarations := slices.Concat(
+		asDeclarations(maps.Values(p.resources)),
+		asDeclarations(maps.Values(p.objects)),
+		asDeclarations(maps.Values(p.enums)))
 
 	// Sort the declarations as specified
 	switch order {
@@ -246,4 +233,13 @@ func (p *Package) rankedObjectComparison(left Declaration, right Declaration) in
 	rightName := strings.ToLower(right.Name())
 
 	return strings.Compare(leftName, rightName)
+}
+
+func asDeclarations[T Declaration](items iter.Seq[T]) []Declaration {
+	var result []Declaration
+	for item := range items {
+		result = append(result, item)
+	}
+
+	return result
 }

--- a/internal/model/package.go
+++ b/internal/model/package.go
@@ -236,6 +236,7 @@ func (p *Package) rankedObjectComparison(left Declaration, right Declaration) in
 }
 
 func asDeclarations[T Declaration](items iter.Seq[T]) []Declaration {
+	//nolint:prealloc // don't want to iterate the sequence twice
 	var result []Declaration
 	for item := range items {
 		result = append(result, item)

--- a/internal/model/package.go
+++ b/internal/model/package.go
@@ -143,7 +143,7 @@ func (p *Package) catalogCrossReferences() {
 
 	usages := p.indexUsage()
 	for name, usage := range usages {
-		if decl, ok := p.Declaration(name); !ok {
+		if decl, ok := p.Declaration(name); ok {
 			if can, ok := decl.(canSetUsage); ok {
 				slices.SortFunc(usage, ComparePropertyReferences)
 				can.SetUsage(usage)

--- a/internal/model/package_builder.go
+++ b/internal/model/package_builder.go
@@ -18,33 +18,32 @@ type PackageBuilder struct {
 
 // Build creates a new Package from the builder.
 func (b *PackageBuilder) Build() *Package {
-	// Calculate total size for all declarations
-	totalDeclarations := len(b.Resources) + len(b.Objects) + len(b.Enums)
-
 	result := &Package{
-		cfg:          b.Config,
-		declarations: make(map[string]Declaration, totalDeclarations),
-		ranks:        make(map[string]int, totalDeclarations),
-		metadata:     b.Metadata,
-		log:          b.Log,
+		cfg:       b.Config,
+		resources: make(map[string]*Resource, len(b.Resources)),
+		objects:   make(map[string]*Object, len(b.Objects)),
+		enums:     make(map[string]*Enum, len(b.Enums)),
+		ranks:     make(map[string]int, len(b.Resources)+len(b.Objects)+len(b.Enums)),
+		metadata:  b.Metadata,
+		log:       b.Log,
 	}
 
 	// Add all resources
 	for _, d := range b.Resources {
 		d.SetPackage(result)
-		result.declarations[d.Name()] = d
+		result.resources[d.Name()] = d
 	}
 
 	// Add all objects
 	for _, d := range b.Objects {
 		d.SetPackage(result)
-		result.declarations[d.Name()] = d
+		result.objects[d.Name()] = d
 	}
 
 	// Add all enums
 	for _, d := range b.Enums {
 		d.SetPackage(result)
-		result.declarations[d.Name()] = d
+		result.enums[d.Name()] = d
 	}
 
 	result.catalogCrossReferences()

--- a/internal/model/package_builder.go
+++ b/internal/model/package_builder.go
@@ -19,35 +19,35 @@ type PackageBuilder struct {
 // Build creates a new Package from the builder.
 func (b *PackageBuilder) Build() *Package {
 	result := &Package{
-		cfg:       b.Config,
-		resources: make(map[string]*Resource, len(b.Resources)),
-		objects:   make(map[string]*Object, len(b.Objects)),
-		enums:     make(map[string]*Enum, len(b.Enums)),
-		ranks:     make(map[string]int, len(b.Resources)+len(b.Objects)+len(b.Enums)),
-		metadata:  b.Metadata,
-		log:       b.Log,
+		cfg:      b.Config,
+		ranks:    make(map[string]int, len(b.Resources)+len(b.Objects)+len(b.Enums)),
+		metadata: b.Metadata,
+		log:      b.Log,
 	}
 
-	// Add all resources
-	for _, d := range b.Resources {
-		d.SetPackage(result)
-		result.resources[d.Name()] = d
-	}
-
-	// Add all objects
-	for _, d := range b.Objects {
-		d.SetPackage(result)
-		result.objects[d.Name()] = d
-	}
-
-	// Add all enums
-	for _, d := range b.Enums {
-		d.SetPackage(result)
-		result.enums[d.Name()] = d
-	}
+	result.resources = indexByName(b.Resources, result)
+	result.objects = indexByName(b.Objects, result)
+	result.enums = indexByName(b.Enums, result)
 
 	result.catalogCrossReferences()
 	result.calculateRanks()
+
+	return result
+}
+
+type indexable interface {
+	Name() string
+	SetPackage(pkg *Package)
+}
+
+// indexByName creates a map of items indexed by their name.
+func indexByName[N indexable](items []N, pkg *Package) map[string]N {
+	result := make(map[string]N, len(items))
+
+	for _, item := range items {
+		item.SetPackage(pkg)
+		result[item.Name()] = item
+	}
 
 	return result
 }


### PR DESCRIPTION
Modify the Declaration interface to be more concise and remove unnecessary methods, making it immutable.

Also separates different resource types in the Package struct and uses a helper function to index declarations.